### PR TITLE
Fix error in counting open/close braces

### DIFF
--- a/index.html
+++ b/index.html
@@ -2028,7 +2028,8 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 					if(countBrackets){
 						if(allLines[i].includes('{')){
 							braces += (allLines[i].match(/{/g) || []).length;
-						}else if(allLines[i].includes('}')){
+						}
+						if(allLines[i].includes('}')){
 							braces -= (allLines[i].match(/}/g) || []).length;
 							if(braces == 0){
 								drawPos[drawPos.length-1].end = i;


### PR DESCRIPTION
Change from `else if` to `if`. The same line can have both '{' and '}' characters, for example:
```
} else if (true) {
```
In the above case, if we use 'else if' then we will miss counting the '}' and therefore our function will not close correctly.