### PR TITLE
Add opening bracket as requirement for function matching

### DIFF
--- a/index.html
+++ b/index.html
@@ -2070,7 +2070,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 					if(funName == drawPos[j].name){
 						// find lines where drawPos[i].name sits
 						for(var i=0; i<allLines.length; i++){
-							if(allLines[i].includes(drawPos[j].name)){
+							if(allLines[i].includes(drawPos[j].name + '(')){
 								functionPos.push(i);
 							}
 						}


### PR DESCRIPTION
When looking for instances of our function, add the requirement that the function name needs to be followed with a '(' character. 

Otherwise for example if we have two functions, `myFunc` and `myFunc1` and we are looking for `myFunc`, then the second function will be mistakenly matched. By including the '(', we will search for `myFunc(` and thus `myFunc1` will not be matched.