### PR TITLE
handful of updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 
 
 		/* INIT */
-		let currentRevision = 19;
+		let currentRevision = 20;
 		let developBranch = false;
 
 		// resetP5(); // manual reset
@@ -329,7 +329,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 			'debugMode': false,
 			'safeMode': false,
 			'sketches': [],
-			'cocoding': {'active':false, 'nick':'', 'namespace':'', 'lockdown':false, 'level':'', 'token':0, 'sync':false, 'request':false, 'writemode':false, 'color':'#00aa00', 'cursor':{'row':0, 'column':0}},
+			'cocoding': {'active':false, 'timestamp':null, 'nick':'', 'namespace':'', 'lockdown':false, 'level':'', 'token':0, 'sync':false, 'request':false, 'writemode':false, 'color':'#00aa00', 'cursor':{'row':0, 'column':0}},
 			'scripts': ['includes/p5/p5.min.js', 'includes/p5/addons/p5.sound.min.js'],
 			'theme': 'ace/theme/gob',
 			'themeBG': '#052544',
@@ -1239,6 +1239,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 			// make sure all settings are there
 			if(settings.revision == undefined || settings.revision < currentRevision){
 				settings.revision = currentRevision;
+				settings.version = initSettings.version;
 				Object.keys(initSettings).forEach(function(k){
 					if(!settings.hasOwnProperty(k)){
 						settings[k] = initSettings[k];
@@ -1293,6 +1294,9 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 					cocodingReset();
 				}
 				settings.cocoding.active = true;
+				if(settings.cocoding.timestamp == null){
+					settings.cocoding.timestamp = timeStamp();
+				}
 				menuCocode.style.display = 'block';
 				settings.fileName = ccSpace;
 				settings.cocoding.namespace = settings.fileName;
@@ -1350,25 +1354,54 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 			initSortable();
 		}
 
-		// save skettch as...
+		// padding version numbers of sketch
+		function pad(num, size) {
+			var s = "0000" + num;
+			return s.substr(s.length-size);
+		}
+
+		// use sketch versions instead of timestamp
+		function versionCheck(sketchName){
+			let tempName = sketchName;
+			let forkScores = tempName.split('_');
+			if(forkScores.length > 0){
+				let forkVersion = forkScores[forkScores.length-1];
+				if(!isNaN(forkVersion) && forkVersion.length == 3){
+					forkScores[forkScores.length-1] = pad(parseInt(forkVersion)+1, 3);
+				}else{
+					forkScores.push('001');
+				}
+			}
+			tempName = forkScores.join('_');
+
+			// check entire sketches for dup version name
+			while(searchSketches(tempName, settings.sketches)){
+				tempName = versionCheck(tempName);
+			}
+				return tempName;
+		}
+
+		// save sketch as...
 		function cloneSketch(){
-			let forkName = settings.fileName;
-			settings.fileName = forkName+'_'+timeStamp();
+			let forkName = versionCheck(settings.fileName);			
+			settings.fileName = forkName;
 			settings.sketches.unshift({'type':'sketch', 'name':settings.fileName});
 			updateSketches();
 			localStorage[settings.fileName] = editor.getValue();
 			editor.focus(); 
 			editor.session.off('change', cloneSketch);
-			
 		}
 
 		function cloneSketchCOCODING(){
-			let forkSession = settings.cocoding.namespace;
+			let forkSession = 'cc_'+settings.cocoding.namespace+'_'+settings.cocoding.timestamp;
 			if(searchJSON(settings.sketches, 'name', forkSession).length == 0){
 				addFolder(forkSession);
 			}
-			let forkName = forkSession+'_'+timeStamp();
+			// let forkName = forkSession+'_'+timeStamp();
+			let forkName = versionCheck(settings.fileName);			
+
 			settings.fileName = forkName;
+			updateSettings();
 			let forkObj = searchJSON(settings.sketches, 'name', forkSession)[0];
 			forkObj.contents.unshift({'type':'sketch', 'name':forkName});
 			forkObj.toggle = 'expand';
@@ -1685,7 +1718,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 
 											// each base folder
 											if(searchSketches(jsonItem.name, settings.sketches)){ 
-												jsonItem.name += '_' + timeStamp();
+												jsonItem.name += '_'+ timeStamp(); //versionCheck(jsonItem.name);
 											}
 
 											// each recursive sketch/folder within
@@ -1750,7 +1783,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 
 				// if duplicate, give unique name
 				if(searchSketches(rnc.name, settings.sketches)){ // && rnc.type == 'sketch'
-					rnc.name += '_' + timeStamp();
+					rnc.name += '_'+ timeStamp(); // versionCheck(rnc.name);
 					fixNamecheck(objSketches, rncPName, rnc.name);
 				}
 
@@ -1775,7 +1808,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 			let jsonSketches = obj.sketches;
 			for(let i=0; i < jsonSketches.length; i++){
 				if(searchSketches(jsonSketches[i][keyName], settings.sketches)){
-					jsonSketches[i][keyName] += '_' + timeStamp();
+					jsonSketches[i][keyName] = versionCheck(jsonSketches[i][keyName]);
 				}
 			}			
 		}
@@ -2136,11 +2169,27 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 				k.remove();
 			});
 
+			// catch active sketch in trashed folder
+			// let dataIDType = searchJSON(settings.sketches, 'name', dataID)[0];
+			// if(dataIDType.type === 'folder'){
+			// 	for(let i=0; i < dataIDType.contents.length; i++){
+			// 		if(settings.fileName === dataIDType.contents[i].name){
+			// 			sketchInFolder = true;
+			// 		}
+			// 	}
+			// }
+
 			localStorage.removeItem(dataID);
 			selElm.remove();
 
 			getOrder();
-			if(dataID === settings.fileName && !settings.cocoding.active){
+
+			let sketchIsGone = false;
+			if(!searchSketches(settings.fileName, settings.sketches)){
+				sketchIsGone = true;
+			}
+
+			if((dataID === settings.fileName || sketchIsGone)&& !settings.cocoding.active){
 				// *** issue if trashing folder containing active sketch...
 				loadSketch(loadLatest());
 			}

--- a/index.html
+++ b/index.html
@@ -380,6 +380,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 		paused = false,
 		markerID = [],
 		errorTimer,
+		consoleTimer,
 		snippets,
 		forceRecompile = false,
 		p5vars = {'frameCount':0, 'mouseX':0, 'mouseY':0},
@@ -1058,6 +1059,13 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 		// check for errors
 		editor.getSession().on('changeAnnotation', function(){
 			let annot = editor.getSession().getAnnotations();
+			
+			// extra debug info (too raw.. but nice to have better p5.js specific debugging in console)
+			// for (var key in annot) {
+			// 	if (annot.hasOwnProperty(key))
+			// 	console.log(annot[key].text + "on line " + " " + annot[key].row);
+			// }
+
 			validCode = true;
 			for(let i=0; i < annot.length; i++){
 				if(annot[i].type === 'error'){
@@ -1143,6 +1151,10 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 			scrollIntoView: 'cursor',
 			readOnly:!0
 		});
+
+		// fix german keyboard binding for /
+		editor.commands.bindKey("cmd-shift-7", "togglecomment")
+		editor.commands.bindKey("ctrl-shift-7", "togglecomment")
 
 		// beautify!
 		let beautifyOptions = {
@@ -1657,7 +1669,9 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 		    	myDropzone.files = []; // clear list
 		    });
 		    this.on("dragenter", function(file, responseText) {
-		    	divDrop.style.display = "block";
+		    	if(event.dataTransfer.dropEffect != 'move'){
+		    		divDrop.style.display = "block";
+		    	}
 		    });
 		    this.on("dragleave", function(file, responseText) {
 		    	divDrop.style.display = "none";
@@ -1666,7 +1680,11 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 		    	divDrop.style.display = "none";
 		    });
 		    this.on("dragover", function(file, responseText) {
-		    	divDrop.style.display = "block";
+		    	// event.preventDefault();
+		    	// console.log(event.dataTransfer.dropEffect);
+		    	if(event.dataTransfer.dropEffect != 'move'){
+		    		divDrop.style.display = "block";
+		    	}
 		    });
 		    this.on("error", function(file, responseText) {
 		    	vex.dialog.alert({
@@ -2312,6 +2330,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 
 		function checkErrorsWorker(){
 			let annos = editor.getSession().getAnnotations();
+
 			if(settings.debugMode){console.log(annos)};
 			let errorsFound = false;
 			for(let i=0; i < annos.length; i++){
@@ -2341,6 +2360,25 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 			}
 		});
 
+		function consoleMessage(msg, timeDelay){
+			p5console.value = msg;
+			p5console.style.display = 'block';
+			if(timeDelay != undefined && timeDelay != 0){
+				if(consoleTimer != undefined){
+					clearTimeout(consoleTimer);
+				}
+				consoleTimer = setTimeout(consoleHide, timeDelay*1000);
+			}
+		}
+
+		function consoleHide(){
+			if(consoleTimer != undefined){
+				clearTimeout(consoleTimer);
+			}
+			p5console.value = '';
+			p5console.style.display = 'none';
+		}
+
 
 
 		/* COMPILE CODE */
@@ -2358,7 +2396,14 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 				r : (codeNoComments.match(/\}/g) || []).length
 			}
 			if(cbCount.l == 0 || cbCount.l != cbCount.r){
+				let missingBracket = "'}'";
+				if(cbCount.l < cbCount.r){
+					missingBracket = "'{'";
+				}
+				consoleMessage("Missing "+missingBracket+". Find mistake then recompile.", 0)
 				return false;
+			}else{
+				consoleHide();
 			}
 
 			if((currCode.search('for') == -1 && currCode.search('while') == -1) || forceRecompile){
@@ -3671,7 +3716,7 @@ function tri(x1, y1, x2, y2, x3, y3, fc){
 			menuCocodeHolder.style.display = 'block';
 			editor.setValue('// Loading COCODING Session: '+settings.cocoding.namespace, 1);
 			cocode = new CocodeApp(settings.cocoding.namespace);
-			
+			// consoleMessage("When COCODING, code in editor is a sandbox. Clone it regularly to access later.", 0);
 		}
 
 		// reset all cocoding except nick + color

--- a/style.css
+++ b/style.css
@@ -103,6 +103,7 @@ hr{
 	height:100vh;
 	z-index:0;
 	pointer-events: all;
+	overflow:hidden;
 }
 .p5-frame-cocoding{
 	pointer-events: all;


### PR DESCRIPTION
- fixed dropzone green from firing when changing order of sketches/folders
- added german keyboard binding for commenting blocks of code (cmd/ctrl + shift + 7)
- added fancy error message if missing curly bracket (already prevented compile, now tells you why)
- replacing most clones with versions _001 _002 instead of timestamps, though they're still needed for imports to avoid multiple files with similar name becoming duplicates (pointing to same code)
- added timestamp to cocoding session folder (name of session is just versioned instead of timestamped)
- hopefully solved scrollbars issue from #31 