### PR TITLE
deps: update node-osc to 4.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/ffd8/p5live/",
   "dependencies": {
     "express": "^4.17.1",
-    "node-osc": "^4.1.5",
+    "node-osc": "^4.1.6",
     "request-stats": "^3.0.0",
     "socket.io": "^2.3.0"
   }


### PR DESCRIPTION
4.1.5 is broken on the latest version of Node 12 and 13.
This explicitly bumpy to 4.1.6 to ensure folks local cache
doesn't cause the project to be broken