### PR TITLE
osc crash fixed! + minor fixes/updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # P5LIVE
-v 1.2.5  
+v 1.2.6  
 cc [teddavis.org](http://teddavis.org) – 2019-2020  
 p5.js collaborative live-coding vj environment!
 

--- a/cocoding-server/package.json
+++ b/cocoding-server/package.json
@@ -1,11 +1,14 @@
 {
   "name": "cocoding-server",
-  "version": "1.1.0",
+  "version": "1.2.6",
   "description": "Collaborative live-coding websocket server for P5LIVE",
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
+  },
+  "engines": {
+    "node": "12.x"
   },
   "repository": {
     "type": "git",
@@ -29,8 +32,8 @@
   },
   "homepage": "https://github.com/ffd8/p5live/",
   "dependencies": {
-    "express": "^4.16.4",
+    "express": "^4.17.1",
     "request-stats": "^3.0.0",
-    "socket.io": "^2.2.0"
+    "socket.io": "^2.3.0"
   }
 }

--- a/index.html
+++ b/index.html
@@ -297,9 +297,7 @@ function windowResized() {
 
 // custom ease function
 function ease(iVal, oVal, eVal){
-	let targetX = iVal;
-	let dx = targetX - oVal; 
-	return oVal += dx * eVal;
+	return oVal += (iVal - oVal) * eVal;
 }
 
 // processing compatibility
@@ -340,7 +338,7 @@ function println(msg){
 
 
 		/* INIT */
-		let currentRevision = 29; // 23
+		let currentRevision = 30;
 		let developBranch = false;
 
 		// resetP5(); // manual reset
@@ -362,7 +360,7 @@ function println(msg){
 
 		// settings
 		let initSettings = {
-			'version':'1.2.5',
+			'version':'1.2.6',
 			'revision':currentRevision,
 			'welcome':true,
 			'fontSize':15, 
@@ -1574,6 +1572,7 @@ function println(msg){
 				cocoding();
 			}else if(settings.welcome){
 				loadDefault();
+				menuToggle(true);
 				loadAbout();
 				settings.welcome = false;
 				updateSettings();

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "p5live",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Collaborative live-coding environment for p5.js",
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
+  },
+  "engines": {
+    "node": "12.x"
   },
   "repository": {
     "type": "git",
@@ -29,7 +32,7 @@
   "homepage": "https://github.com/ffd8/p5live/",
   "dependencies": {
     "express": "^4.17.1",
-    "node-osc": "^4.1.5",
+    "node-osc": "^4.1.7",
     "request-stats": "^3.0.0",
     "socket.io": "^2.3.0"
   }

--- a/server.js
+++ b/server.js
@@ -97,29 +97,45 @@ io.origins((origin, callback) => {
 });
 
 // OSC
+// let oscConnected = 0, oscDisconnected = 0; // debugger... fixed now??
 if(!online){
 	iop.sockets.on('connection', function (socket) {
 		socket.on("config", function (obj) {
-			// *** find source of random OSC crash...
-			isConnected = true;
+			if(isConnected){
+				closeOSC();
+			}
+			// oscConnected++;
+			// console.log('OSC - connected - ' + oscConnected);
 	    	oscServer = new osc.Server(obj.server.port, obj.server.host);
 		    oscClient = new osc.Client(obj.client.host, obj.client.port);
-		    oscClient.send('/status', socket.sessionId + ' connected');
+			isConnected = true;
+		    // oscClient.send('/status', socket.id + ' connected');
 			oscServer.on('message', function(msg, rinfo) {
 				socket.emit("message", msg);
 			});
 			socket.emit("connected", 1);
 		});
 	 	socket.on("message", function (obj) {
-			oscClient.send.apply(oscClient, obj);
+	 		if(isConnected){
+				oscClient.send.apply(oscClient, obj);
+			}
 	  	});
 		socket.on('disconnect', function(){
 			if (isConnected) {
-				oscServer.close();
-				oscClient.close();
+				closeOSC()
+				// oscDisconnected++;
+				// console.log('OSC - disconnected - ' + oscDisconnected);
 			}
 	  	});
 	});
+}
+
+function closeOSC(){
+	oscServer.close();
+	oscClient.close();
+	oscServer = undefined;
+	oscClient = undefined;
+	isConnected = false;
 }
 
 
@@ -386,8 +402,8 @@ module.exports = Namespace;
 
 const listener = server.listen(port, function() {
 	if(!online){
-  		console.log('P5LIVE is live! visit » http://localhost:' + listener.address().port);
+  		console.log('P5 is LIVE! visit » http://localhost:' + listener.address().port);
 	}else{
-		console.log('P5LIVE is live! Running on port: ' + listener.address().port);
+		console.log('P5 is LIVE! Running on port: ' + listener.address().port);
 	}
 });

--- a/style.css
+++ b/style.css
@@ -184,7 +184,6 @@ hr{
 	resize:none;
 	color:#aaa;
 	outline:none;
-	/*pointer-events: none;*/
 	background:#000;
 	border:none;
 	border-top:1px solid #444;


### PR DESCRIPTION
- node-osc updated latest version that catches errors quietly
- found source of crash.. sometimes osc server/client didn't fully disconnect before creating a new connection. Solves #20 !
- now forcing osc client/server to init incase loading and they exist (didn't close)
- set note engine to 12
- simplified ease function